### PR TITLE
Correct vertex checking typo in edge matching

### DIFF
--- a/scsdk/c++/scsdk/standard_cyborg/sc3d/MeshTopology.cpp
+++ b/scsdk/c++/scsdk/standard_cyborg/sc3d/MeshTopology.cpp
@@ -89,7 +89,7 @@ void MeshTopology::compute(const std::vector<Face3>& faces)
             }
             
             // Similarly, check for an edge matching AC or CA
-            if ((edge.vertex0 == vertexA && edge.vertex1 == vertexC) || (edge.vertex0 == vertexC && edge.vertex0 == vertexA)) {
+            if ((edge.vertex0 == vertexA && edge.vertex1 == vertexC) || (edge.vertex0 == vertexC && edge.vertex1 == vertexA)) {
                 edgeCA = edgeIndex;
                 if (edgeAB != -1) break;
             }


### PR DESCRIPTION
While investigating #12, I noticed the meshing function was performing a comparison which seemed like it might be a typo. The other edge matching checks always check both vertices and it seemed like that should be the case here too. 