### PR TITLE
Fix red coloring in meshed point clouds

### DIFF
--- a/StandardCyborgFusion/Public/Mesh/SCMeshTexturing.mm
+++ b/StandardCyborgFusion/Public/Mesh/SCMeshTexturing.mm
@@ -246,13 +246,21 @@ static NSString * const _MetadataJSONFilename = @"Metadata.json";
                 
                 int foundIndex = cloudGeometry.getClosestVertexIndex(pos);
                 
-                if (0 <= foundIndex && foundIndex < meshGeometry.vertexCount()) {
+                if (0 <= foundIndex && foundIndex < cloudGeometry.vertexCount()) {
                     math::Vec3 closestColor = cloudGeometry.getColors()[foundIndex];
                     newColors.push_back(closestColor);
                 } else {
-                    // use red if we can't find one.
-                    math::Vec3 col(1.0, 0.0, 0.0);
-                    newColors.push_back(col);
+                
+                    if(cloudGeometry.getColors().size() > 0) {
+                        // okay, if we can't find a closest point for some reason, just pick one color from the point cloud as fallback.
+                        math::Vec3 col = cloudGeometry.getColors()[0];
+                        newColors.push_back(col);
+                    } else {
+                        // just to cover all bases.
+                        math::Vec3 col(1.0, 0.0, 0.0);
+                        newColors.push_back(col);
+                    }
+                    
                 }
             }
             meshGeometry.setColors(newColors);


### PR DESCRIPTION
fix red color bug, it was due to a typo. 

hand scan before 

![Screenshot 2024-06-10 at 15 33 56](https://github.com/StandardCyborg/StandardCyborgSDK/assets/602313/2b6d7a1b-1124-4c4e-9116-12b3f1508ae5)

hand scan after

![Screenshot 2024-06-10 at 15 36 17](https://github.com/StandardCyborg/StandardCyborgSDK/assets/602313/b92085d6-21c2-4c5f-9900-f934aa08b34c)

